### PR TITLE
Improve behavior with broken locales, missing folders

### DIFF
--- a/tests/test_directorylist.py
+++ b/tests/test_directorylist.py
@@ -6,6 +6,7 @@ import unittest
 
 from tmx_products.tmx_products import create_directories_list
 
+
 class TestCreateDirectoriesList(unittest.TestCase):
 
     def testStandardProduct(self):

--- a/tests/test_escape.py
+++ b/tests/test_escape.py
@@ -5,6 +5,7 @@ import unittest
 
 from tmx_products.tmx_products import escape
 
+
 class TestEscape(unittest.TestCase):
 
     def testCleanStrings(self):

--- a/tests/test_tmxcreate.py
+++ b/tests/test_tmxcreate.py
@@ -31,6 +31,23 @@ class TestCreateTMXContent(unittest.TestCase):
         self.assertTrue("'test/test.dtd:test_missing' => ''" in tmx_content)
         self.assertFalse(
             "'test/test.dtd:test_extra' => 'Extra string: this one is not available in the reference language'" in tmx_content)
+        self.assertTrue(
+            "'test/test.dtd:test_missing' => ''" in tmx_content)
+
+    def testCreateTMXEncodingError(self):
+        testfiles_path = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), 'testfiles', 'tmx'))
+
+        locale_path = os.path.join(testfiles_path, 'oc')
+        reference_path = os.path.join(testfiles_path, 'en-US')
+        tmx_content = create_tmx_content(
+            reference_path, locale_path, ['mail', 'test'])
+
+        self.assertEqual(len(tmx_content), 5)
+        self.assertTrue(
+            "'test/test.dtd:test1' => 'Test with one \\\\ slash'" in tmx_content)
+        self.assertFalse(
+            "'test/test.dtd:test_missing' => 'This one won\\'t be translated in the locale'" in tmx_content)
 
     def testCreateTMXGaia(self):
         testfiles_path = os.path.abspath(

--- a/tests/testfiles/tmx/en-US/mail/mailTurboMenu.properties
+++ b/tests/testfiles/tmx/en-US/mail/mailTurboMenu.properties
@@ -1,0 +1,2 @@
+MailNews=&Mail and group
+Addressbook=&Address book

--- a/tests/testfiles/tmx/oc/mail/mailTurboMenu.properties
+++ b/tests/testfiles/tmx/oc/mail/mailTurboMenu.properties
@@ -1,0 +1,2 @@
+MailNews=&Corrièr e gropes de discussion
+Addressbook=Qu&asernet d'adreças

--- a/tests/testfiles/tmx/oc/test/test.dtd
+++ b/tests/testfiles/tmx/oc/test/test.dtd
@@ -1,0 +1,3 @@
+<!ENTITY test1 "Test with one \ slash">
+<!ENTITY test2 "Test with single 'quotes'">
+<!ENTITY test2b "Test with escaped single 'quotes'">

--- a/tests/testfiles/tmx/test.dtd
+++ b/tests/testfiles/tmx/test.dtd
@@ -1,0 +1,5 @@
+<!ENTITY test1 "Test with one \ slash">
+<!ENTITY test2 "Test with single 'quotes'">
+<!ENTITY test2b "Test with escaped single 'quotes'">
+<!ENTITY test3 "To \&quot;Open multiple links\&quot;, please enable the \'Draw over other apps\' permission for &brandShortName;">
+<!ENTITY test_missing "This one won't be translated in the locale">

--- a/tmx_products/tmx_products.py
+++ b/tmx_products/tmx_products.py
@@ -81,7 +81,7 @@ def get_strings(package, local_directory, strings_array):
             for entity in item[1]:
                 # String ID is the format folder/filename:entity. Make
                 # sure to remove a starting '/' from the folder's name
-                string_id = '{0}/{1}:{2}'.format(
+                string_id = u'{0}/{1}:{2}'.format(
                     local_directory.lstrip('/'), item[0], entity)
                 strings_array[string_id] = item[1][entity].get_value()
         elif (isinstance(item[1], silme.core.Package)):
@@ -121,15 +121,22 @@ def create_tmx_content(reference_repo, locale_repo, dirs):
         try:
             l10nPackage_reference = rcsClient.get_package(
                 path_reference, object_type='entitylist')
-        except:
-            print 'Silme couldn\'t extract data for ', path_reference
+        except Exception as e:
+            print 'Silme couldn\'t extract data for', path_reference
+            print e
+            continue
+
+        if not os.path.isdir(path_locale):
+            # Folder doesn't exist for this locale, don't log a warning,
+            # just continue to the next folder.
             continue
 
         try:
             l10nPackage_locale = rcsClient.get_package(
                 path_locale, object_type='entitylist')
-        except:
-            print 'Silme couldn\'t extract data for ', path_locale
+        except Exception as e:
+            print 'Silme couldn\'t extract data for', path_locale
+            print e
             continue
 
         strings_reference = {}


### PR DESCRIPTION
* If a locale is broken (e.g. ‘oc’), make sure to deal with it when creating a string_id
* Don’t try to use Silme on missing folders (e.g. ‘devtools' on release)
* Print Silme's exception too, to help debugging the issue
* Add test with broken locale (non utf-8 encoding)